### PR TITLE
Space group number to Laue Ops instance

### DIFF
--- a/Source/EbsdLib/LaueOps/LaueOps.cpp
+++ b/Source/EbsdLib/LaueOps/LaueOps.cpp
@@ -395,6 +395,52 @@ std::vector<LaueOps::Pointer> LaueOps::getOrientationOpsVector()
 }
 
 // -----------------------------------------------------------------------------
+LaueOps::Pointer LaueOps::getOrientationOpsFromSpaceGroupNumber(size_t sgNumber)
+{
+  std::array<size_t, 32> sgpg = {1, 2, 3, 6, 10, 16, 25, 47, 75, 81, 83, 89, 99, 111, 123, 143, 147, 149, 156, 162, 168, 174, 175, 177, 183, 187, 191, 195, 200, 207, 215, 221};
+  std::array<size_t, 32> pgLaue = {1, 1, 2, 2, 2, 22, 22, 22, 4, 4, 4, 42, 42, 42, 42, 3, 3, 32, 32, 32, 6, 6, 6, 62, 62, 62, 62, 23, 23, 43, 43, 43};
+
+  size_t pgNumber = 0;
+  for(size_t i = 0; i < sgpg.size(); i++)
+  {
+    if(sgpg[i] > sgNumber)
+    {
+      pgNumber = i;
+      break;
+    }
+  }
+
+  size_t value = pgLaue.at(pgNumber);
+  switch(value)
+  {
+  case 1:
+    return TriclinicOps::New();
+  case 2:
+    return MonoclinicOps::New();
+  case 22:
+    return OrthoRhombicOps::New();
+  case 4:
+    return TetragonalLowOps::New();
+  case 42:
+    return TetragonalOps::New();
+  case 3:
+    return TrigonalLowOps::New();
+  case 32:
+    return TrigonalOps::New();
+  case 6:
+    return HexagonalLowOps::New();
+  case 62:
+    return HexagonalOps::New();
+  case 23:
+    return CubicLowOps::New();
+  case 43:
+    return CubicOps::New();
+  default:
+    return LaueOps::NullPointer();
+  }
+}
+
+// -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
 std::vector<QString> LaueOps::GetLaueNames()

--- a/Source/EbsdLib/LaueOps/LaueOps.h
+++ b/Source/EbsdLib/LaueOps/LaueOps.h
@@ -77,6 +77,12 @@ class EbsdLib_EXPORT LaueOps
      */
     static std::vector<LaueOps::Pointer> getOrientationOpsVector();
 
+    /**
+     * @brief getOrientationOpsFromSpaceGroupNumber
+     * @param sgNumber
+     * @return
+     */
+    static Pointer getOrientationOpsFromSpaceGroupNumber(size_t sgNumber);
 
     /**
      * @brief GetLaueNames Returns the names of the Laue Classes


### PR DESCRIPTION
Adding method that is given a space group number and converts it to the appropriate laue ops instance.

Signed-off-by: Joey Kleingers <joey.kleingers@bluequartz.net>