### PR TITLE
Fixed incorrect symmetry operator count when finding Cubic FZ orientations

### DIFF
--- a/Source/EbsdLib/LaueOps/CubicOps.cpp
+++ b/Source/EbsdLib/LaueOps/CubicOps.cpp
@@ -35,8 +35,6 @@
 
 #include "CubicOps.h"
 
-#include <memory>
-
 #ifdef EbsdLib_USE_PARALLEL_ALGORITHMS
 #include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
@@ -71,58 +69,58 @@ static const int symSize2 = 8;
 
 static const int k_OdfSize = 5832;
 static const int k_MdfSize = 5832;
-static const int k_NumSymQuats = 24;
+static const int k_SymOpsCount = 24;
 static const int k_NumMdfBins = 13;
 
-static const QuatD QuatSym[24] = {QuatD(0.000000000, 0.000000000, 0.000000000, 1.000000000),
-                                     QuatD(1.000000000, 0.000000000, 0.000000000, 0.000000000),
-                                     QuatD(0.000000000, 1.000000000, 0.000000000, 0.000000000),
-                                     QuatD(0.000000000, 0.000000000, 1.000000000, 0.000000000),
-                                     QuatD(EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
-                                     QuatD(0.000000000, EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
-                                     QuatD(0.000000000, 0.000000000, EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2),
-                                     QuatD(-EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
-                                     QuatD(0.000000000, -EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
-                                     QuatD(0.000000000, 0.000000000, -EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2),
-                                     QuatD(EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
-                                     QuatD(-EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
-                                     QuatD(0.000000000, EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
-                                     QuatD(0.000000000, -EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
-                                     QuatD(EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
-                                     QuatD(-EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
-                                     QuatD(0.500000000, 0.500000000, 0.500000000, 0.500000000),
-                                     QuatD(-0.500000000, -0.500000000, -0.500000000, 0.500000000),
-                                     QuatD(0.500000000, -0.500000000, 0.500000000, 0.500000000),
-                                     QuatD(-0.500000000, 0.500000000, -0.500000000, 0.500000000),
-                                     QuatD(-0.500000000, 0.500000000, 0.500000000, 0.500000000),
-                                     QuatD(0.500000000, -0.500000000, -0.500000000, 0.500000000),
-                                     QuatD(-0.500000000, -0.500000000, 0.500000000, 0.500000000),
-                                     QuatD(0.500000000, 0.500000000, -0.500000000, 0.500000000)};
+static const std::vector<QuatD> QuatSym = {QuatD(0.000000000, 0.000000000, 0.000000000, 1.000000000),
+                                           QuatD(1.000000000, 0.000000000, 0.000000000, 0.000000000),
+                                           QuatD(0.000000000, 1.000000000, 0.000000000, 0.000000000),
+                                           QuatD(0.000000000, 0.000000000, 1.000000000, 0.000000000),
+                                           QuatD(EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
+                                           QuatD(0.000000000, EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
+                                           QuatD(0.000000000, 0.000000000, EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2),
+                                           QuatD(-EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
+                                           QuatD(0.000000000, -EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2),
+                                           QuatD(0.000000000, 0.000000000, -EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2),
+                                           QuatD(EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
+                                           QuatD(-EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000, 0.000000000),
+                                           QuatD(0.000000000, EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
+                                           QuatD(0.000000000, -EbsdLib::Constants::k_1OverRoot2, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
+                                           QuatD(EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
+                                           QuatD(-EbsdLib::Constants::k_1OverRoot2, 0.000000000, EbsdLib::Constants::k_1OverRoot2, 0.000000000),
+                                           QuatD(0.500000000, 0.500000000, 0.500000000, 0.500000000),
+                                           QuatD(-0.500000000, -0.500000000, -0.500000000, 0.500000000),
+                                           QuatD(0.500000000, -0.500000000, 0.500000000, 0.500000000),
+                                           QuatD(-0.500000000, 0.500000000, -0.500000000, 0.500000000),
+                                           QuatD(-0.500000000, 0.500000000, 0.500000000, 0.500000000),
+                                           QuatD(0.500000000, -0.500000000, -0.500000000, 0.500000000),
+                                           QuatD(-0.500000000, -0.500000000, 0.500000000, 0.500000000),
+                                           QuatD(0.500000000, 0.500000000, -0.500000000, 0.500000000)};
 
-static const double RodSym[24][3] = {{0.0, 0.0, 0.0},
-                                     {10000000000.0, 0.0, 0.0},
-                                     {0.0, 10000000000.0, 0.0},
-                                     {0.0, 0.0, 10000000000.0},
-                                     {1.0, 0.0, 0.0},
-                                     {0.0, 1.0, 0.0},
-                                     {0.0, 0.0, 1.0},
-                                     {-1.0, 0.0, 0.0},
-                                     {0.0, -1.0, 0.0},
-                                     {0.0, 0.0, -1.0},
-                                     {10000000000.0, 10000000000.0, 0.0},
-                                     {-10000000000.0, 10000000000.0, 0.0},
-                                     {0.0, 10000000000.0, 10000000000.0},
-                                     {0.0, -10000000000.0, 10000000000.0},
-                                     {10000000000.0, 0.0, 10000000000.0},
-                                     {-10000000000.0, 0.0, 10000000000.0},
-                                     {1.0, 1.0, 1.0},
-                                     {-1.0, -1.0, -1.0},
-                                     {1.0, -1.0, 1.0},
-                                     {-1.0, 1.0, -1.0},
-                                     {-1.0, 1.0, 1.0},
-                                     {1.0, -1.0, -1.0},
-                                     {-1.0, -1.0, 1.0},
-                                     {1.0, 1.0, -1.0}};
+static const std::vector<OrientationD> RodSym = {{0.0, 0.0, 0.0},
+                                                 {10000000000.0, 0.0, 0.0},
+                                                 {0.0, 10000000000.0, 0.0},
+                                                 {0.0, 0.0, 10000000000.0},
+                                                 {1.0, 0.0, 0.0},
+                                                 {0.0, 1.0, 0.0},
+                                                 {0.0, 0.0, 1.0},
+                                                 {-1.0, 0.0, 0.0},
+                                                 {0.0, -1.0, 0.0},
+                                                 {0.0, 0.0, -1.0},
+                                                 {10000000000.0, 10000000000.0, 0.0},
+                                                 {-10000000000.0, 10000000000.0, 0.0},
+                                                 {0.0, 10000000000.0, 10000000000.0},
+                                                 {0.0, -10000000000.0, 10000000000.0},
+                                                 {10000000000.0, 0.0, 10000000000.0},
+                                                 {-10000000000.0, 0.0, 10000000000.0},
+                                                 {1.0, 1.0, 1.0},
+                                                 {-1.0, -1.0, -1.0},
+                                                 {1.0, -1.0, 1.0},
+                                                 {-1.0, 1.0, -1.0},
+                                                 {-1.0, 1.0, 1.0},
+                                                 {1.0, -1.0, -1.0},
+                                                 {-1.0, -1.0, 1.0},
+                                                 {1.0, 1.0, -1.0}};
 
 static const double SlipDirections[12][3] = {{0.0, 1.0, -1.0}, {1.0, 0.0, -1.0}, {1.0, -1.0, 0.0}, {1.0, -1.0, 0.0}, {1.0, 0.0, 1.0}, {0.0, 1.0, 1.0},
                                              {1.0, 1.0, 0.0},  {0.0, 1.0, 1.0},  {1.0, 0.0, -1.0}, {1.0, 1.0, 0.0},  {1.0, 0.0, 1.0}, {0.0, 1.0, -1.0}};
@@ -130,53 +128,53 @@ static const double SlipDirections[12][3] = {{0.0, 1.0, -1.0}, {1.0, 0.0, -1.0},
 static const double SlipPlanes[12][3] = {{1.0, 1.0, 1.0},  {1.0, 1.0, 1.0},  {1.0, 1.0, 1.0},  {1.0, 1.0, -1.0}, {1.0, 1.0, -1.0}, {1.0, 1.0, -1.0},
                                          {1.0, -1.0, 1.0}, {1.0, -1.0, 1.0}, {1.0, -1.0, 1.0}, {-1.0, 1.0, 1.0}, {-1.0, 1.0, 1.0}, {-1.0, 1.0, 1.0}};
 
-static const double MatSym[24][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+static const double MatSym[k_SymOpsCount][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}},
+                                                   {{1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}},
 
-                                        {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
+                                                   {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}},
+                                                   {{1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}},
 
-                                        {{0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}},
+                                                   {{0.0, 0.0, -1.0}, {0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}},
 
-                                        {{0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}},
+                                                   {{0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}},
 
-                                        {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
+                                                   {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
+                                                   {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
+                                                   {{0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
+                                                   {{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}},
+                                                   {{0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}},
 
-                                        {{0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
+                                                   {{0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
 
-                                        {{0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}},
+                                                   {{0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}},
 
-                                        {{0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
+                                                   {{0.0, 0.0, -1.0}, {1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}},
 
-                                        {{0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}},
+                                                   {{0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}},
 
-                                        {{0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
+                                                   {{0.0, 0.0, -1.0}, {-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
 
-                                        {{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}},
+                                                   {{0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}},
 
-                                        {{0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
+                                                   {{0.0, 0.0, 1.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}},
 
-                                        {{0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}},
+                                                   {{0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}},
+                                                   {{-1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, {0.0, 1.0, 0.0}},
 
-                                        {{0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}},
+                                                   {{0.0, 0.0, 1.0}, {0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}},
 
-                                        {{-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}},
+                                                   {{-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}},
 
-                                        {{0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}},
+                                                   {{0.0, 0.0, -1.0}, {0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}},
 
-                                        {{0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}}};
+                                                   {{0.0, -1.0, 0.0}, {-1.0, 0.0, 0.0}, {0.0, 0.0, -1.0}}};
 
 } // namespace CubicHigh
 
@@ -225,7 +223,7 @@ int CubicOps::getMdfPlotBins() const
 // -----------------------------------------------------------------------------
 int CubicOps::getNumSymOps() const
 {
-  return CubicHigh::k_NumSymQuats;
+  return CubicHigh::k_SymOpsCount;
 }
 
 // -----------------------------------------------------------------------------
@@ -247,7 +245,7 @@ std::string CubicOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 OrientationD CubicOps::calculateMisorientation(const QuatD& q1, const QuatD& q2) const
 {
-  return calculateMisorientationInternal(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2);
+  return calculateMisorientationInternal(CubicHigh::QuatSym, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
@@ -256,14 +254,14 @@ OrientationF CubicOps::calculateMisorientation(const QuatF& q1f, const QuatF& q2
 {
   QuatD q1 = q1f.to<double>();
   QuatD q2 = q2f.to<double>();
-  OrientationD axisAngle = calculateMisorientationInternal(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2);
+  OrientationD axisAngle = calculateMisorientationInternal(CubicHigh::QuatSym, q1, q2);
   return axisAngle;
 }
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationD CubicOps::calculateMisorientationInternal(const QuatD* quatsym, size_t numsym, const QuatD& q1, const QuatD& q2) const
+OrientationD CubicOps::calculateMisorientationInternal(const std::vector<QuatD>& quatsym, const QuatD& q1, const QuatD& q2) const
 {
   double wmin = 9999999.0f; //,na,nb,nc;
   QuatD qco;
@@ -560,7 +558,7 @@ void CubicOps::getMatSymOp(int i, float g[3][3]) const
 // -----------------------------------------------------------------------------
 OrientationType CubicOps::getODFFZRod(const OrientationType& rod) const
 {
-  return _calcRodNearestOrigin(CubicHigh::RodSym, CubicHigh::k_NumSymQuats, rod);
+  return _calcRodNearestOrigin(CubicHigh::RodSym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -571,7 +569,7 @@ OrientationType CubicOps::getMDFFZRod(const OrientationType& inRod) const
   double w, n1, n2, n3;
   double FZw, FZn1, FZn2, FZn3;
 
-  OrientationType rod = _calcRodNearestOrigin(CubicHigh::RodSym, 12, inRod);
+  OrientationType rod = _calcRodNearestOrigin(CubicHigh::RodSym, inRod);
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
   n1 = ax[0];
@@ -625,21 +623,21 @@ OrientationType CubicOps::getMDFFZRod(const OrientationType& inRod) const
 
 QuatD CubicOps::getNearestQuat(const QuatD& q1, const QuatD& q2) const
 {
-  return _calcNearestQuat(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(CubicHigh::QuatSym, q1, q2);
 }
 
 QuatF CubicOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatD q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatD q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatD temp = _calcNearestQuat(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, q1, q2);
+  QuatD temp = _calcNearestQuat(CubicHigh::QuatSym, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
 
 QuatD CubicOps::getFZQuat(const QuatD& qr) const
 {
-  return _calcQuatNearestOrigin(CubicHigh::QuatSym, CubicHigh::k_NumSymQuats, qr);
+  return _calcQuatNearestOrigin(CubicHigh::QuatSym, qr);
 }
 
 // -----------------------------------------------------------------------------
@@ -700,7 +698,7 @@ OrientationType CubicOps::determineEulerAngles(double random[3], int choose) con
 // -----------------------------------------------------------------------------
 OrientationType CubicOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(CubicHigh::k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(CubicHigh::k_SymOpsCount);
   QuatD quat = OrientationTransformation::eu2qu<OrientationType, QuatD>(synea);
   QuatD qc = CubicHigh::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatD, OrientationType>(qc);
@@ -901,7 +899,7 @@ void CubicOps::getSchmidFactorAndSS(double load[3], double plane[3], double dire
   directionMag *= loadMag;
 
   // loop over symmetry operators finding highest schmid factor
-  for(int i = 0; i < CubicHigh::k_NumSymQuats; i++)
+  for(int i = 0; i < CubicHigh::k_SymOpsCount; i++)
   {
     // compute slip system
     double slipPlane[3] = {0};
@@ -1619,7 +1617,7 @@ EbsdLib::Rgb CubicOps::generateIPFColor(double phi1, double phi, double phi2, do
   OrientationType om(9); // Reusable for the loop
   QuatD q1 = OrientationTransformation::eu2qu<OrientationType, QuatD>(eu);
 
-  for(int j = 0; j < CubicHigh::k_NumSymQuats; j++)
+  for(int j = 0; j < CubicHigh::k_SymOpsCount; j++)
   {
     QuatD qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatD, OrientationType>(qu).toGMatrix(g);

--- a/Source/EbsdLib/LaueOps/CubicOps.h
+++ b/Source/EbsdLib/LaueOps/CubicOps.h
@@ -235,7 +235,7 @@ protected:
    * @param q2
    * @return
    */
-  OrientationD calculateMisorientationInternal(const QuatD* quatsym, size_t numsym, const QuatD& q1, const QuatD& q2) const override;
+  OrientationD calculateMisorientationInternal(const std::vector<QuatD>& quatsym, const QuatD& q1, const QuatD& q2) const override;
 
   /**
    * @brief area preserving projection of volume preserving transformation (for C. Shuch and S. Patala coloring legend generation)

--- a/Source/EbsdLib/LaueOps/HexagonalOps.cpp
+++ b/Source/EbsdLib/LaueOps/HexagonalOps.cpp
@@ -36,7 +36,6 @@
 #include "HexagonalOps.h"
 
 #include <array>
-#include <memory>
 
 // Include this FIRST because there is a needed define for some compiles
 // to expose some of the constants needed below
@@ -71,50 +70,51 @@ static const int symSize2 = 6;
 
 static const int k_OdfSize = 15552;
 static const int k_MdfSize = 15552;
-static const int k_NumSymQuats = 12;
+static const int k_SymOpsCount = 12;
 static const int k_NumMdfBins = 20;
 
-static const QuatD QuatSym[12] = {
+static const std::vector<QuatD> QuatSym = {
     QuatD(0.000000000, 0.000000000, 0.000000000, 1.000000000), QuatD(0.000000000, 0.000000000, 0.500000000, 0.866025400), QuatD(0.000000000, 0.000000000, 0.866025400, 0.500000000),
     QuatD(0.000000000, 0.000000000, 1.000000000, 0.000000000), QuatD(0.000000000, 0.000000000, 0.866025400, -0.50000000), QuatD(0.000000000, 0.000000000, 0.500000000, -0.86602540),
     QuatD(1.000000000, 0.000000000, 0.000000000, 0.000000000), QuatD(0.866025400, 0.500000000, 0.000000000, 0.000000000), QuatD(0.500000000, 0.866025400, 0.000000000, 0.000000000),
     QuatD(0.000000000, 1.000000000, 0.000000000, 0.000000000), QuatD(-0.50000000, 0.866025400, 0.000000000, 0.000000000), QuatD(-0.86602540, 0.500000000, 0.000000000, 0.000000000)};
 
-static const double RodSym[12][3] = {{0.0, 0.0, 0.0},
-                                     {0.0, 0.0, 0.57735},
-                                     {0.0, 0.0, 1.73205},
-                                     {0.0, 0.0, 1000000000000.0},
-                                     {0.0, 0.0, -1.73205},
-                                     {0.0, 0.0, -0.57735},
-                                     {1000000000000.0, 0.0, 0.0},
-                                     {8660254000000.0, 5000000000000.0, 0.0},
-                                     {5000000000000.0, 8660254000000.0, 0.0},
-                                     {0.0, 1000000000000.0, 0.0},
-                                     {-5000000000000.0, 8660254000000.0, 0.0},
-                                     {-8660254000000.0, 5000000000000.0, 0.0}};
-static const double MatSym[12][3][3] = {{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
+static const std::vector<OrientationD> RodSym = {{0.0, 0.0, 0.0},
+                                                 {0.0, 0.0, 0.57735},
+                                                 {0.0, 0.0, 1.73205},
+                                                 {0.0, 0.0, 1000000000000.0},
+                                                 {0.0, 0.0, -1.73205},
+                                                 {0.0, 0.0, -0.57735},
+                                                 {1000000000000.0, 0.0, 0.0},
+                                                 {8660254000000.0, 5000000000000.0, 0.0},
+                                                 {5000000000000.0, 8660254000000.0, 0.0},
+                                                 {0.0, 1000000000000.0, 0.0},
+                                                 {-5000000000000.0, 8660254000000.0, 0.0},
+                                                 {-8660254000000.0, 5000000000000.0, 0.0}};
+static const double MatSym[k_SymOpsCount][3][3] = {
+    {{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{-0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
+    {{-0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{-0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
+    {{-0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
+    {{0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
+    {{-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
+    {{0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, 1.0}},
 
-                                        {{-0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
+    {{-0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
+    {{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{-0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
+    {{-0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.5, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}},
+    {{0.5, static_cast<double>(EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
+    {{-1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, -1.0}},
 
-                                        {{0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}}};
+    {{0.5, static_cast<double>(-EbsdLib::Constants::k_Root3Over2), 0.0}, {static_cast<double>(-EbsdLib::Constants::k_Root3Over2), -0.5, 0.0}, {0.0, 0.0, -1.0}}};
 
 // Use a namespace for some detail that only this class needs
 } // namespace HexagonalHigh
@@ -164,7 +164,7 @@ int HexagonalOps::getMdfPlotBins() const
 // -----------------------------------------------------------------------------
 int HexagonalOps::getNumSymOps() const
 {
-  return HexagonalHigh::k_NumSymQuats;
+  return HexagonalHigh::k_SymOpsCount;
 }
 
 // -----------------------------------------------------------------------------
@@ -185,7 +185,7 @@ std::string HexagonalOps::getSymmetryName() const
 // -----------------------------------------------------------------------------
 OrientationD HexagonalOps::calculateMisorientation(const QuatD& q1, const QuatD& q2) const
 {
-  return calculateMisorientationInternal(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2);
+  return calculateMisorientationInternal(HexagonalHigh::QuatSym, q1, q2);
 }
 
 // -----------------------------------------------------------------------------
@@ -193,7 +193,7 @@ OrientationF HexagonalOps::calculateMisorientation(const QuatF& q1f, const QuatF
 {
   QuatD q1 = q1f.to<double>();
   QuatD q2 = q2f.to<double>();
-  OrientationD axisAngle = calculateMisorientationInternal(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2);
+  OrientationD axisAngle = calculateMisorientationInternal(HexagonalHigh::QuatSym, q1, q2);
   return axisAngle;
 }
 
@@ -243,8 +243,7 @@ void HexagonalOps::getMatSymOp(int i, float g[3][3]) const
 // -----------------------------------------------------------------------------
 OrientationType HexagonalOps::getODFFZRod(const OrientationType& rod) const
 {
-  int numsym = 12;
-  return _calcRodNearestOrigin(HexagonalHigh::RodSym, numsym, rod);
+  return _calcRodNearestOrigin(HexagonalHigh::RodSym, rod);
 }
 
 // -----------------------------------------------------------------------------
@@ -256,7 +255,7 @@ OrientationType HexagonalOps::getMDFFZRod(const OrientationType& inRod) const
   double FZn1 = 0.0, FZn2 = 0.0, FZn3 = 0.0, FZw = 0.0;
   double n1n2mag;
 
-  OrientationType rod = _calcRodNearestOrigin(HexagonalHigh::RodSym, 12, inRod);
+  OrientationType rod = _calcRodNearestOrigin(HexagonalHigh::RodSym, inRod);
 
   OrientationType ax = OrientationTransformation::ro2ax<OrientationType, OrientationType>(rod);
 
@@ -305,14 +304,14 @@ OrientationType HexagonalOps::getMDFFZRod(const OrientationType& inRod) const
 
 QuatD HexagonalOps::getNearestQuat(const QuatD& q1, const QuatD& q2) const
 {
-  return _calcNearestQuat(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2);
+  return _calcNearestQuat(HexagonalHigh::QuatSym, q1, q2);
 }
 
 QuatF HexagonalOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 {
   QuatD q1(q1f[0], q1f[1], q1f[2], q1f[3]);
   QuatD q2(q2f[0], q2f[1], q2f[2], q2f[3]);
-  QuatD temp = _calcNearestQuat(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, q1, q2);
+  QuatD temp = _calcNearestQuat(HexagonalHigh::QuatSym, q1, q2);
   QuatF out(temp.x(), temp.y(), temp.z(), temp.w());
   return out;
 }
@@ -322,7 +321,7 @@ QuatF HexagonalOps::getNearestQuat(const QuatF& q1f, const QuatF& q2f) const
 // -----------------------------------------------------------------------------
 QuatD HexagonalOps::getFZQuat(const QuatD& qr) const
 {
-  return _calcQuatNearestOrigin(HexagonalHigh::QuatSym, HexagonalHigh::k_NumSymQuats, qr);
+  return _calcQuatNearestOrigin(HexagonalHigh::QuatSym, qr);
 }
 
 // -----------------------------------------------------------------------------
@@ -383,7 +382,7 @@ OrientationType HexagonalOps::determineEulerAngles(double random[3], int choose)
 // -----------------------------------------------------------------------------
 OrientationType HexagonalOps::randomizeEulerAngles(const OrientationType& synea) const
 {
-  size_t symOp = getRandomSymmetryOperatorIndex(HexagonalHigh::k_NumSymQuats);
+  size_t symOp = getRandomSymmetryOperatorIndex(HexagonalHigh::k_SymOpsCount);
   QuatD quat = OrientationTransformation::eu2qu<OrientationType, QuatD>(synea);
   QuatD qc = HexagonalHigh::QuatSym[symOp] * quat;
   return OrientationTransformation::qu2eu<QuatD, OrientationType>(qc);
@@ -1228,7 +1227,7 @@ EbsdLib::Rgb HexagonalOps::generateIPFColor(double phi1, double phi, double phi2
   OrientationType om(9); // Reusable for the loop
   QuatD q1 = OrientationTransformation::eu2qu<OrientationType, QuatD>(eu);
 
-  for(int j = 0; j < HexagonalHigh::k_NumSymQuats; j++)
+  for(int j = 0; j < HexagonalHigh::k_SymOpsCount; j++)
   {
     QuatD qu = getQuatSymOp(j) * q1;
     OrientationTransformation::qu2om<QuatD, OrientationType>(qu).toGMatrix(g);

--- a/Source/EbsdLib/LaueOps/LaueOps.cpp
+++ b/Source/EbsdLib/LaueOps/LaueOps.cpp
@@ -94,12 +94,12 @@ QuatD LaueOps::getFZQuat(const QuatD& qr) const
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationD LaueOps::calculateMisorientationInternal(const QuatD* quatsym, size_t numsym, const QuatD& q1, const QuatD& q2) const
+OrientationD LaueOps::calculateMisorientationInternal(const std::vector<QuatD>& quatsym, const QuatD& q1, const QuatD& q2) const
 {
   OrientationD axisAngleMin(0.0, 0.0, 0.0, std::numeric_limits<double>::max());
   QuatD qc;
   QuatD qr = q1 * (q2.conjugate());
-
+  size_t numsym = quatsym.size();
   for(size_t i = 0; i < numsym; i++)
   {
     qc = quatsym[i] * qr;
@@ -140,7 +140,7 @@ OrientationD LaueOps::calculateMisorientationInternal(const QuatD* quatsym, size
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-OrientationType LaueOps::_calcRodNearestOrigin(const double rodsym[24][3], int numsym, const OrientationType& inRod) const
+OrientationType LaueOps::_calcRodNearestOrigin(const std::vector<OrientationD>& rodsym, const OrientationType& inRod) const
 {
   double denom = 0.0f, dist = 0.0f;
   double smallestdist = 100000000.0f;
@@ -151,7 +151,8 @@ OrientationType LaueOps::_calcRodNearestOrigin(const double rodsym[24][3], int n
   rod[0] *= rod[3];
   rod[1] *= rod[3];
   rod[2] *= rod[3];
-  for(int i = 0; i < numsym; i++)
+  size_t numsym = rodsym.size();
+  for(size_t i = 0; i < numsym; i++)
   {
     denom = 1 - (rod[0] * rodsym[i][0] + rod[1] * rodsym[i][1] + rod[2] * rodsym[i][2]);
     rc1 = (rod[0] + rodsym[i][0] - (rod[1] * rodsym[i][2] - rod[2] * rodsym[i][1])) / denom;
@@ -184,14 +185,14 @@ OrientationType LaueOps::_calcRodNearestOrigin(const double rodsym[24][3], int n
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-QuatD LaueOps::_calcNearestQuat(const QuatD quatsym[24], int numsym, const QuatD& q1, const QuatD& q2) const
+QuatD LaueOps::_calcNearestQuat(const std::vector<QuatD>& quatsym, const QuatD& q1, const QuatD& q2) const
 {
   QuatD out;
   double dist = 0.0;
   double smallestdist = 1000000.0f;
   QuatD qmax;
-
-  for(int i = 0; i < numsym; i++)
+  size_t numsym = quatsym.size();
+  for(size_t i = 0; i < numsym; i++)
   {
     QuatD qc = quatsym[i] * q2;
     if(qc.w() < 0)
@@ -213,13 +214,13 @@ QuatD LaueOps::_calcNearestQuat(const QuatD quatsym[24], int numsym, const QuatD
   return out;
 }
 
-QuatD LaueOps::_calcQuatNearestOrigin(const QuatD quatsym[24], int numsym, const QuatD& qr) const
+QuatD LaueOps::_calcQuatNearestOrigin(const std::vector<QuatD>& quatsym, const QuatD& qr) const
 {
   double dist = 0.0;
   double smallestdist = 1000000.0f;
   QuatD qmax;
-
-  for(int i = 0; i < numsym; i++)
+  size_t numsym = quatsym.size();
+  for(size_t i = 0; i < numsym; i++)
   {
     QuatD qc = quatsym[i] * qr;
 

--- a/Source/EbsdLib/LaueOps/LaueOps.h
+++ b/Source/EbsdLib/LaueOps/LaueOps.h
@@ -36,7 +36,6 @@
 
 #include <memory>
 #include <vector>
-
 #include <string>
 
 #include "EbsdLib/EbsdLib.h"
@@ -285,13 +284,13 @@ protected:
    * @param q2 Input Quaternion 2
    * @return Returns Axis-Angle <XYZ>W form.
    */
-  virtual OrientationD calculateMisorientationInternal(const QuatD* quatsym, size_t numsym, const QuatD& q1, const QuatD& q2) const;
+  virtual OrientationD calculateMisorientationInternal(const std::vector<QuatD>& quatsym, const QuatD& q1, const QuatD& q2) const;
 
-  OrientationType _calcRodNearestOrigin(const double rodsym[24][3], int numsym, const OrientationType& rod) const;
+  OrientationType _calcRodNearestOrigin(const std::vector<OrientationD>& rodsym, const OrientationType& rod) const;
 
-  QuatD _calcNearestQuat(const QuatD quatsym[24], int numsym, const QuatD& q1, const QuatD& q2) const;
+  QuatD _calcNearestQuat(const std::vector<QuatD>& quatsym, const QuatD& q1, const QuatD& q2) const;
 
-  QuatD _calcQuatNearestOrigin(const QuatD quatsym[24], int numsym, const QuatD& qr) const;
+  QuatD _calcQuatNearestOrigin(const std::vector<QuatD>& quatsym, const QuatD& qr) const;
 
   int _calcMisoBin(double dim[3], double bins[3], double step[3], const OrientationType& homochoric) const;
   void _calcDetermineHomochoricValues(double random[3], double init[3], double step[3], int32_t phi[3], double& r1, double& r2, double& r3) const;

--- a/Source/EbsdLib/LaueOps/SO3Sampler.h
+++ b/Source/EbsdLib/LaueOps/SO3Sampler.h
@@ -33,7 +33,6 @@
 
 #include <list>
 #include <memory>
-
 #include <string>
 
 #include "EbsdLib/EbsdLib.h"


### PR DESCRIPTION

Took the opportunity to clean up the symmetry operators and convert them from "C"
style 2D arrays into std::vector of QuatD or OrientationD types. This cleans up the
API in some of the called methods where we don't have to send in a count of the
symmetry operators possibly introducing errors (like what was fixed).

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>