### PR TITLE
Add generateIPFTriangleLegend virtual function to LaueOps base class

### DIFF
--- a/Source/EbsdLib/LaueOps/CubicLowOps.h
+++ b/Source/EbsdLib/LaueOps/CubicLowOps.h
@@ -234,7 +234,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/CubicOps.h
+++ b/Source/EbsdLib/LaueOps/CubicOps.h
@@ -234,7 +234,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
   /**
    * @brief generates a misorientation coloring legend

--- a/Source/EbsdLib/LaueOps/HexagonalLowOps.h
+++ b/Source/EbsdLib/LaueOps/HexagonalLowOps.h
@@ -235,7 +235,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/HexagonalOps.h
+++ b/Source/EbsdLib/LaueOps/HexagonalOps.h
@@ -235,7 +235,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/LaueOps.h
+++ b/Source/EbsdLib/LaueOps/LaueOps.h
@@ -293,6 +293,12 @@ public:
    */
   virtual std::array<std::string, 3> getDefaultPoleFigureNames() const = 0;
 
+  /**
+   * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
+   * @return
+   */
+  virtual EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const = 0;
+
 protected:
   LaueOps();
 

--- a/Source/EbsdLib/LaueOps/MonoclinicOps.h
+++ b/Source/EbsdLib/LaueOps/MonoclinicOps.h
@@ -233,7 +233,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/OrthoRhombicOps.h
+++ b/Source/EbsdLib/LaueOps/OrthoRhombicOps.h
@@ -235,7 +235,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/TetragonalLowOps.h
+++ b/Source/EbsdLib/LaueOps/TetragonalLowOps.h
@@ -234,7 +234,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/TetragonalOps.h
+++ b/Source/EbsdLib/LaueOps/TetragonalOps.h
@@ -234,7 +234,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/TriclinicOps.h
+++ b/Source/EbsdLib/LaueOps/TriclinicOps.h
@@ -234,7 +234,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/TrigonalLowOps.h
+++ b/Source/EbsdLib/LaueOps/TrigonalLowOps.h
@@ -235,7 +235,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:

--- a/Source/EbsdLib/LaueOps/TrigonalOps.h
+++ b/Source/EbsdLib/LaueOps/TrigonalOps.h
@@ -234,7 +234,7 @@ public:
    * @brief generateStandardTriangle Generates an RGBA array that is a color "Standard" IPF Triangle Legend used for IPF Color Maps.
    * @return
    */
-  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const;
+  EbsdLib::UInt8ArrayType::Pointer generateIPFTriangleLegend(int imageDim) const override;
 
 protected:
 public:


### PR DESCRIPTION
This correct issue #20.

It seems that ` generateMisorientationTriangleLegend` is also missing as a virtual function, I can resolve also that in this pull request if that can help.